### PR TITLE
:bug: Convert pick times to UTCDateTime

### DIFF
--- a/anisotropio/translators/qm2X.py
+++ b/anisotropio/translators/qm2X.py
@@ -60,6 +60,11 @@ def qm2mfast(events, run_dir, archive, stations, out_dir=None, run_subname=""):
         picks = picks[picks["Phase"] == "S"]
         picks = picks[picks["PickTime"] != "-1"]
 
+        # --- Filter for automatic S picks ---
+        picks["PickTime"] = picks["PickTime"].apply(
+            lambda x: obspy.UTCDateTime(x)
+        )
+
         # Add check here for any picks?
 
         # --- Find min/max pick times and use to query data from archive ---
@@ -75,8 +80,8 @@ def qm2mfast(events, run_dir, archive, stations, out_dir=None, run_subname=""):
 
         # --- For each pick, slice relevant window of data and write SAC ---
         for _, pick in picks.iterrows():
+            pick_time = pick.PickTime
             station = stations[stations["Name"] == pick.Station].squeeze()
-            pick_time = obspy.UTCDateTime(pick.PickTime)
 
             tmp_stream = stream.select(station=pick.Station)
             tmp_stream = tmp_stream.slice(


### PR DESCRIPTION
## What is the purpose of this Pull Request? 

Convert `picks.PickTime` to `obspy.UTCDateTime` object before feeding to
`archive.read_waveform_data()`.

Also fixed a minor bug later in the same function where the `pick_time`
variable was not defined.


### Relevant Issues

This commit fixes the bug raised in Issue #1, as well as another minor issue specified, with pick_time variable not defined

## Test cases
Tested using Quakemigrate Volcanotectonic example directory and UoCam archive, runs without issue and creates expected files

- [x] All examples run without any new warnings


### System details
Ubuntu 20.04.4 LTS
Python 3.8.13

### Final checklist
- [x] `main` base branch selected?







